### PR TITLE
[Go Client] Fix output and path param encoding

### DIFF
--- a/?/.config/jgit/config
+++ b/?/.config/jgit/config
@@ -1,0 +1,3 @@
+[filesystem "Oracle Corporation|1.8.0_342|grpcfuse"]
+	timestampResolution = 1001 microseconds
+	minRacyThreshold = 0 nanoseconds

--- a/?/.config/jgit/config
+++ b/?/.config/jgit/config
@@ -1,3 +1,0 @@
-[filesystem "Oracle Corporation|1.8.0_342|grpcfuse"]
-	timestampResolution = 1001 microseconds
-	minRacyThreshold = 0 nanoseconds

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -118,6 +118,13 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		{{/returnType}}
 	)
 
+	type ResponseEnvelope struct {
+		{{#returnType}}
+		Data {{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}} `json:"data"`
+		{{/returnType}}
+		Error error `json:"error"`
+	}
+
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "{{{classname}}}Service.{{{nickname}}}")
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, &GenericOpenAPIError{error: err.Error()}
@@ -379,13 +386,13 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		if localVarHTTPResponse.StatusCode == {{{code}}} {
 		{{/wildcard}}
 		{{/range}}
-			var v {{{dataType}}}
+			var v ResponseEnvelope
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
 			}
-			newErr.model = v
+			newErr.model = v.Error
 			{{^-last}}
 			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
 			{{/-last}}
@@ -400,7 +407,8 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	{{#returnType}}
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	var responseEnvelope ResponseEnvelope
+	err = a.client.decode(&responseEnvelope, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,
@@ -410,7 +418,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	{{/returnType}}
-	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, nil
+	return {{#returnType}}responseEnvelope.Data, {{/returnType}}localVarHTTPResponse, responseEnvelope.Error
 }
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -153,7 +153,11 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 		return t.Format(time.RFC3339)
 	}
 
-	return fmt.Sprintf("%v", obj)
+	objJson, err := parameterToJson(obj)
+	if err != nil {
+		return fmt.Sprintf("%v", obj)
+	}
+	return objJson
 }
 
 // helper for converting interface{} parameters to json strings


### PR DESCRIPTION
This PR fixes the output object of the Go client by unwrapping the response envelope that comes back from PAPI, since that is not specified in the OpenAPI file. This PR also fixes path param encoding by using JSON directly in the URL. I was going to write tests for this but there aren't any for the current Go generator, so I think that should come as a different PR to catch everything.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
